### PR TITLE
feat: waiting for reconnect

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -31,6 +31,10 @@ version = "*"
 name = 'piot/ordered-datagram-c'
 version = "*"
 
+[[dependencies]]
+name = 'piot/secure-random-c'
+version = "*"
+
 # ------
 
 [[development]]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(deps/piot/nimble-serialize-c/src/lib)
 add_subdirectory(deps/piot/nimble-steps-c/src/lib)
 add_subdirectory(deps/piot/nimble-steps-serialize-c/src/lib)
 add_subdirectory(deps/piot/ordered-datagram-c/src/lib)
+add_subdirectory(deps/piot/secure-random-c/src/lib)
 add_subdirectory(deps/piot/stats-c/src/lib)
 add_subdirectory(deps/piot/tiny-libc/src/lib)
 

--- a/src/include/nimble-server/forced_step.h
+++ b/src/include/nimble-server/forced_step.h
@@ -9,9 +9,14 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include <nimble-steps-serialize/types.h>
+
 struct NimbleServerParticipantConnection;
 
-int nimbleServerInsertForcedSteps(struct NimbleServerParticipantConnection* foundParticipantConnection, size_t dropped);
-ssize_t nimbleServerCreateForcedStep(struct NimbleServerParticipantConnection* connection, uint8_t* defaultStepBuffer, size_t maxCount);
+int nimbleServerInsertForcedSteps(struct NimbleServerParticipantConnection* foundParticipantConnection,
+                                  size_t dropped);
+ssize_t nimbleServerCreateForcedStep(struct NimbleServerParticipantConnection* connection,
+                                     uint8_t* defaultStepBuffer,
+                                     size_t maxCount);
 
 #endif

--- a/src/include/nimble-server/participant_connection.h
+++ b/src/include/nimble-server/participant_connection.h
@@ -19,7 +19,7 @@ struct NimbleServerTransportConnection;
 
 typedef struct NimbleServerParticipantReferences {
     size_t participantReferenceCount;
-    struct NimbleServerParticipant* participantReferences[MAX_LOCAL_PLAYERS];
+    struct NimbleServerParticipant* participantReferences[NIMBLE_SERIALIZE_MAX_LOCAL_PLAYERS];
 } NimbleServerParticipantReferences;
 
 typedef enum NimbleServerParticipantConnectionState {

--- a/src/include/nimble-server/participant_connection.h
+++ b/src/include/nimble-server/participant_connection.h
@@ -40,10 +40,12 @@ typedef struct NimbleServerParticipantConnection {
 
     StatsInt incomingStepCountInBufferStats;
     struct NimbleServerTransportConnection* transportConnection;
-    ImprintAllocator* allocatorWithNoFree;
     size_t forcedStepInRowCounter;
     size_t providedStepsInARow;
     size_t impedingDisconnectCounter;
+    size_t waitingForReconnectTimer;
+    size_t waitingForReconnectMaxTimer;
+    NimbleSerializeParticipantConnectionSecret secret;
     Clog log;
 } NimbleServerParticipantConnection;
 
@@ -53,7 +55,7 @@ void nimbleServerParticipantConnectionInit(NimbleServerParticipantConnection* se
                                   Clog log);
 
 void nimbleServerParticipantConnectionReset(NimbleServerParticipantConnection* self);
-
+void nimbleServerParticipantConnectionReInit(NimbleServerParticipantConnection* self, struct NimbleServerTransportConnection* transportConnection, StepId latestAuthoritativeStepId);
 bool nimbleServerParticipantConnectionHasParticipantId(const NimbleServerParticipantConnection* self, uint8_t participantId);
 
 #endif

--- a/src/include/nimble-server/participant_connection.h
+++ b/src/include/nimble-server/participant_connection.h
@@ -25,6 +25,7 @@ typedef struct NimbleServerParticipantReferences {
 typedef enum NimbleServerParticipantConnectionState {
     NimbleServerParticipantConnectionStateNormal,
     NimbleServerParticipantConnectionStateImpendingDisconnect,
+    NimbleServerParticipantConnectionStateWaitingForReconnect,
     NimbleServerParticipantConnectionStateDisconnected
 } NimbleServerParticipantConnectionState;
 

--- a/src/include/nimble-server/participant_connection.h
+++ b/src/include/nimble-server/participant_connection.h
@@ -24,7 +24,6 @@ typedef struct NimbleServerParticipantReferences {
 
 typedef enum NimbleServerParticipantConnectionState {
     NimbleServerParticipantConnectionStateNormal,
-    NimbleServerParticipantConnectionStateImpendingDisconnect,
     NimbleServerParticipantConnectionStateWaitingForReconnect,
     NimbleServerParticipantConnectionStateDisconnected
 } NimbleServerParticipantConnectionState;
@@ -46,6 +45,7 @@ typedef struct NimbleServerParticipantConnection {
     size_t waitingForReconnectTimer;
     size_t waitingForReconnectMaxTimer;
     NimbleSerializeParticipantConnectionSecret secret;
+    bool hasAddedFirstAcceptedSteps;
     Clog log;
 } NimbleServerParticipantConnection;
 

--- a/src/include/nimble-server/participant_connections.h
+++ b/src/include/nimble-server/participant_connections.h
@@ -11,6 +11,7 @@
 #include <clog/clog.h>
 #include <nimble-server/participants.h>
 #include <nimble-steps/steps.h>
+#include <nimble-serialize/types.h>
 
 struct NimbleServerParticipantConnection;
 
@@ -40,6 +41,9 @@ nimbleServerParticipantConnectionsFindConnection(NimbleServerParticipantConnecti
 struct NimbleServerParticipantConnection*
 nimbleServerParticipantConnectionsFindConnectionForTransport(NimbleServerParticipantConnections* self,
                                                              uint32_t transportConnectionId);
+struct NimbleServerParticipantConnection*
+nimbleServerParticipantConnectionsFindConnectionFromSecret(NimbleServerParticipantConnections* self,
+                                                           NimbleSerializeParticipantConnectionSecret connectionSecret);
 int nimbleServerParticipantConnectionsCreate(NimbleServerParticipantConnections* self,
                                              NimbleServerParticipants* gameParticipants,
                                              struct NimbleServerTransportConnection* transportConnection,

--- a/src/include/nimble-server/req_connect.h
+++ b/src/include/nimble-server/req_connect.h
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Peter Bjorklund. All rights reserved.
-*  Licensed under the MIT License. See LICENSE in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Peter Bjorklund. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 #ifndef NIMBLE_SERVER_REQ_CONNECT_H
 #define NIMBLE_SERVER_REQ_CONNECT_H
 

--- a/src/include/nimble-server/req_connect.h
+++ b/src/include/nimble-server/req_connect.h
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Peter Bjorklund. All rights reserved.
+*  Licensed under the MIT License. See LICENSE in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+#ifndef NIMBLE_SERVER_REQ_CONNECT_H
+#define NIMBLE_SERVER_REQ_CONNECT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct NimbleServer;
+struct FldOutStream;
+struct FldInStream;
+struct NimbleServerTransportConnection;
+
+int nimbleServerReqConnect(struct NimbleServer* self, struct NimbleServerTransportConnection* transportConnection,
+                           struct FldInStream* inStream, struct FldOutStream* outStream);
+
+#endif

--- a/src/include/nimble-server/req_download_game_state.h
+++ b/src/include/nimble-server/req_download_game_state.h
@@ -14,7 +14,7 @@ struct FldOutStream;
 struct FldInStream;
 
 int nimbleServerReqDownloadGameState(struct NimbleServerTransportConnection* transportConnection, struct ImprintAllocator* pageAllocator,
-                            const struct NimbleServerGame* game, NimbleSerializeVersion applicationVersion,
+                            const struct NimbleServerGame* game,
                             struct FldInStream* inStream, struct FldOutStream* outStream);
 
 #endif

--- a/src/include/nimble-server/server.h
+++ b/src/include/nimble-server/server.h
@@ -39,6 +39,7 @@ typedef struct NimbleServerSetup {
     size_t maxParticipantCount;
     size_t maxSingleParticipantStepOctetCount;
     size_t maxParticipantCountForEachConnection;
+    size_t maxWaitingForReconnectTicks;
     size_t maxGameStateOctetCount;
     const uint8_t* zeroInputOctets;
     size_t zeroInputOctetCount;

--- a/src/include/nimble-server/transport_connection.h
+++ b/src/include/nimble-server/transport_connection.h
@@ -24,6 +24,8 @@
 
 typedef enum NimbleServerTransportConnectionPhase {
     NbTransportConnectionPhaseIdle,
+    NbTransportConnectionPhaseWaitingForValidConnect,
+    NbTransportConnectionPhaseConnected,
     NbTransportConnectionPhaseInitialStateDetermined,
     NbTransportConnectionPhaseDisconnected
 } NimbleServerTransportConnectionPhase;

--- a/src/include/nimble-server/transport_connection.h
+++ b/src/include/nimble-server/transport_connection.h
@@ -43,6 +43,7 @@ typedef struct NimbleServerTransportConnection {
     size_t debugCounter;
     Clog log;
     bool isUsed;
+    bool useDebugStreams;
     uint8_t noRangesToSendCounter;
     NimbleServerTransportConnectionPhase phase;
 } NimbleServerTransportConnection;

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -26,12 +26,13 @@ set_tornado(nimble-server-lib)
 target_include_directories(nimble-server-lib PUBLIC ../include)
 
 
-target_link_libraries(nimble-server-lib 
-  PUBLIC discoid
-  PUBLIC nimble-serialize
-  PUBLIC nimble-steps-serialize
-  PUBLIC stats
-  PUBLIC blob-stream
-  PUBLIC datagram-transport
-  PUBLIC ordered-datagram)
+target_link_libraries(nimble-server-lib PUBLIC 
+  discoid
+  nimble-serialize
+  nimble-steps-serialize
+  stats
+  blob-stream
+  datagram-transport
+  ordered-datagram
+  secure-random)
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(nimble-server-lib STATIC
   participant_connection.c
   participant_connections.c
   participants.c
+  req_connect.c
   req_game_join.c
   req_game_state.c
   req_game_state_ack.c

--- a/src/lib/authoritative_steps.c
+++ b/src/lib/authoritative_steps.c
@@ -125,8 +125,8 @@ static int composeOneAuthoritativeStep(NimbleServerParticipantConnections* conne
                                   connection->id, participantId)
                 continue;
             }
-
             fldOutStreamWriteUInt8(&composeStream, participantId);
+            fldOutStreamWriteUInt8(&composeStream, NimbleSerializeParticipantStateNormal);
             fldOutStreamWriteUInt8(&composeStream, localStepOctetCount);
             fldOutStreamWriteOctets(&composeStream, splitStepBuffer, localStepOctetCount);
             // CLOG_C_INFO(&connection->log, "connection %d. Wrote participant ID %d (octetCount %d)", connection->id,

--- a/src/lib/authoritative_steps.c
+++ b/src/lib/authoritative_steps.c
@@ -9,6 +9,7 @@
 #include <nimble-server/participant_connection.h>
 #include <nimble-server/participant_connections.h>
 #include <nimble-server/transport_connection.h>
+#include <nimble-steps-serialize/types.h>
 
 #define NIMBLE_SERVER_LOGGING 1
 
@@ -110,9 +111,18 @@ static int composeOneAuthoritativeStep(NimbleServerParticipantConnections* conne
             if (participantId == 0) {
                 CLOG_C_SOFT_ERROR(&connection->log, "participantId zero is reserved")
             }
-            uint8_t localStepOctetCount;
-            fldInStreamReadUInt8(&stepInStream, &localStepOctetCount);
-            fldInStreamReadOctets(&stepInStream, splitStepBuffer, localStepOctetCount);
+            uint8_t localStepOctetCount = 0;
+            NimbleSerializeParticipantConnectState readLocalConnectState = NimbleSerializeParticipantConnectStateNormal;
+            bool hasMask = participantId & 0x80;
+            uint8_t mask = 0;
+            if (hasMask) {
+                fldInStreamReadUInt8(&stepInStream, &readLocalConnectState);
+                participantId = participantId & 0x7f;
+                mask = 0x80;
+            } else {
+                fldInStreamReadUInt8(&stepInStream, &localStepOctetCount);
+                fldInStreamReadOctets(&stepInStream, splitStepBuffer, localStepOctetCount);
+            }
 #if NIMBLE_SERVER_LOGGING && 0
             CLOG_C_INFO(&connection->log, "step %08X connection %d. Read participant ID %d (octetCount %hhu)",
                         lookingFor, connection->id, participantId, localStepOctetCount)
@@ -125,10 +135,13 @@ static int composeOneAuthoritativeStep(NimbleServerParticipantConnections* conne
                                   connection->id, participantId)
                 continue;
             }
-            fldOutStreamWriteUInt8(&composeStream, participantId);
-            fldOutStreamWriteUInt8(&composeStream, NimbleSerializeParticipantStateNormal);
-            fldOutStreamWriteUInt8(&composeStream, localStepOctetCount);
-            fldOutStreamWriteOctets(&composeStream, splitStepBuffer, localStepOctetCount);
+            fldOutStreamWriteUInt8(&composeStream, mask | participantId);
+            if (mask) {
+                fldOutStreamWriteUInt8(&composeStream, readLocalConnectState);
+            } else {
+                fldOutStreamWriteUInt8(&composeStream, localStepOctetCount);
+                fldOutStreamWriteOctets(&composeStream, splitStepBuffer, localStepOctetCount);
+            }
             // CLOG_C_INFO(&connection->log, "connection %d. Wrote participant ID %d (octetCount %d)", connection->id,
             // participantId, localStepOctetCount)
             foundParticipantCount++;

--- a/src/lib/check_for_disconnects.c
+++ b/src/lib/check_for_disconnects.c
@@ -16,6 +16,55 @@ static void disconnectConnection(NimbleServerParticipantConnections* connections
     nimbleServerParticipantConnectionsRemove(connections, connection);
 }
 
+static void setConnectionInWaitingForReconnect(NimbleServerParticipantConnection* connection)
+{
+    connection->state = NimbleServerParticipantConnectionStateWaitingForReconnect;
+    connection->waitingForReconnectTimer = 0;
+}
+
+static void checkDisconnectInNormal(NimbleServerParticipantConnection* connection, Clog* log)
+{
+    (void) log;
+    size_t forcedStepInRowCounterThreshold = 120U;
+    if (!blobStreamLogicOutIsComplete(&connection->transportConnection->blobStreamLogicOut)) {
+        forcedStepInRowCounterThreshold = 280U;
+    }
+
+    if (connection->forcedStepInRowCounter > forcedStepInRowCounterThreshold) {
+        CLOG_C_DEBUG(log, "disconnect connection %d due to not providing steps for a long time", connection->id)
+        setConnectionInWaitingForReconnect(connection);
+    } else if (connection->forcedStepInRowCounter > 4U) {
+        if (connection->state == NimbleServerParticipantConnectionStateNormal) {
+            connection->state = NimbleServerParticipantConnectionStateImpendingDisconnect;
+            connection->impedingDisconnectCounter++;
+            if (connection->impedingDisconnectCounter >= 3) {
+                CLOG_C_DEBUG(log, "disconnect connection %d due to multiple occurrences of not providing steps",
+                             connection->id)
+                setConnectionInWaitingForReconnect(connection);
+            }
+        }
+    }
+}
+
+static void checkDisconnectWhileImpendingDisconnect(NimbleServerParticipantConnection* connection)
+{
+    if (connection->impedingDisconnectCounter > 0 && connection->providedStepsInARow > 62 * 60U) {
+        connection->impedingDisconnectCounter = 0;
+        connection->state = NimbleServerParticipantConnectionStateNormal;
+    }
+}
+
+static void checkWaitingForReconnect(NimbleServerParticipantConnections* connections,
+                                     NimbleServerParticipantConnection* connection)
+{
+    connection->waitingForReconnectTimer++;
+    if (connection->waitingForReconnectTimer < connection->waitingForReconnectMaxTimer) {
+        return;
+    }
+
+    disconnectConnection(connections, connection);
+}
+
 /// Check all connections and disconnect those that have low network quality.
 /// @param connections transport connections to check
 void nimbleServerCheckForDisconnections(NimbleServerParticipantConnections* connections)
@@ -25,31 +74,19 @@ void nimbleServerCheckForDisconnections(NimbleServerParticipantConnections* conn
         if (!connection->isUsed || connection->transportConnection->phase == NbTransportConnectionPhaseDisconnected) {
             continue;
         }
-        size_t forcedStepInRowCounterThreshold = 120U;
-        if (!blobStreamLogicOutIsComplete(&connection->transportConnection->blobStreamLogicOut)) {
-            forcedStepInRowCounterThreshold = 280U;
-        }
 
-        if (connection->forcedStepInRowCounter > forcedStepInRowCounterThreshold) {
-            CLOG_C_DEBUG(&connections->log, "disconnect connection %d due to not providing steps for a long time",
-                         connection->id)
-            disconnectConnection(connections, connection);
-        } else if (connection->forcedStepInRowCounter > 4U) {
-            if (connection->state == NimbleServerParticipantConnectionStateNormal) {
-                connection->state = NimbleServerParticipantConnectionStateImpendingDisconnect;
-                connection->impedingDisconnectCounter++;
-                if (connection->impedingDisconnectCounter >= 3) {
-                    CLOG_C_DEBUG(&connections->log,
-                                 "disconnect connection %d due to multiple occurrences of not providing steps",
-                                 connection->id)
-                    disconnectConnection(connections, connection);
-                }
-            }
-        }
-
-        if (connection->impedingDisconnectCounter > 0 && connection->providedStepsInARow > 62 * 60U) {
-            connection->impedingDisconnectCounter = 0;
-            connection->state = NimbleServerParticipantConnectionStateNormal;
+        switch (connection->state) {
+            case NimbleServerParticipantConnectionStateNormal:
+                checkDisconnectInNormal(connection, &connections->log);
+                break;
+            case NimbleServerParticipantConnectionStateImpendingDisconnect:
+                checkDisconnectWhileImpendingDisconnect(connection);
+                break;
+            case NimbleServerParticipantConnectionStateWaitingForReconnect:
+                checkWaitingForReconnect(connections, connection);
+                break;
+            case NimbleServerParticipantConnectionStateDisconnected:
+                break;
         }
     }
 }

--- a/src/lib/check_for_disconnects.c
+++ b/src/lib/check_for_disconnects.c
@@ -29,7 +29,7 @@ static void increaseImpendingDisconnectCounter(NimbleServerParticipantConnection
     CLOG_C_DEBUG(&connection->log, "connection unresponsive, increasing counter to %zu",
                  connection->impedingDisconnectCounter)
 
-    if (connection->impedingDisconnectCounter >= 5) {
+    if (connection->impedingDisconnectCounter >= 15) {
         CLOG_C_DEBUG(&connection->log,
                      "set connection in 'waiting for reconnect', due to multiple occurrences of not providing steps")
         setConnectionInWaitingForReconnect(connection);

--- a/src/lib/incoming_predicted_steps.c
+++ b/src/lib/incoming_predicted_steps.c
@@ -82,5 +82,9 @@ int nimbleServerHandleIncomingSteps(NimbleServerGame* foundGame, FldInStream* in
         return addedStepsCount;
     }
 
+    if (addedStepsCount > 0) {
+        foundParticipantConnection->hasAddedFirstAcceptedSteps = true;
+    }
+
     return addedStepsCount;
 }

--- a/src/lib/incoming_predicted_steps.c
+++ b/src/lib/incoming_predicted_steps.c
@@ -83,7 +83,10 @@ int nimbleServerHandleIncomingSteps(NimbleServerGame* foundGame, FldInStream* in
     }
 
     if (addedStepsCount > 0) {
-        foundParticipantConnection->hasAddedFirstAcceptedSteps = true;
+        if (!foundParticipantConnection->hasAddedFirstAcceptedSteps) {
+            foundParticipantConnection->hasAddedFirstAcceptedSteps = true;
+            foundParticipantConnection->forcedStepInRowCounter = 0;
+        }
     }
 
     return addedStepsCount;

--- a/src/lib/participant_connection.c
+++ b/src/lib/participant_connection.c
@@ -53,6 +53,7 @@ void nimbleServerParticipantConnectionReInit(NimbleServerParticipantConnection* 
     self->forcedStepInRowCounter = 0;
     self->impedingDisconnectCounter = 0;
     self->state = NimbleServerParticipantConnectionStateNormal;
+    self->hasAddedFirstAcceptedSteps = false;
 
     statsIntInit(&self->incomingStepCountInBufferStats, 60);
     // Expect that the client will add steps for the next authoritative step

--- a/src/lib/participant_connection.c
+++ b/src/lib/participant_connection.c
@@ -27,19 +27,9 @@ void nimbleServerParticipantConnectionInit(NimbleServerParticipantConnection* se
 
     self->log = log;
     nbsStepsInit(&self->steps, connectionAllocator, combinedStepOctetSize, log);
-    // Expect that the client will add steps for the next authoritative step
-    nbsStepsReInit(&self->steps, currentAuthoritativeStepId);
     self->participantReferences.participantReferenceCount = 0;
-
-    self->allocatorWithNoFree = connectionAllocator;
-    self->transportConnection = transportConnection;
     self->isUsed = false;
-    self->providedStepsInARow = 0;
-    self->forcedStepInRowCounter = 0;
-    self->impedingDisconnectCounter = 0;
-    self->state = NimbleServerParticipantConnectionStateNormal;
-
-    statsIntInit(&self->incomingStepCountInBufferStats, 60);
+    nimbleServerParticipantConnectionReInit(self, transportConnection, currentAuthoritativeStepId);
 }
 
 /// Resets the participant connection
@@ -48,6 +38,25 @@ void nimbleServerParticipantConnectionReset(NimbleServerParticipantConnection* s
 {
     self->isUsed = false;
     self->participantReferences.participantReferenceCount = 0;
+}
+
+
+
+/// Reinitialize the participant connection
+/// @param self participant connection
+/// @param transportConnection the underlying transport connection
+/// @param currentAuthoritativeStepId the authoritative step ID to start from
+void nimbleServerParticipantConnectionReInit(NimbleServerParticipantConnection* self, NimbleServerTransportConnection* transportConnection, StepId currentAuthoritativeStepId)
+{
+    self->providedStepsInARow = 0;
+    self->forcedStepInRowCounter = 0;
+    self->impedingDisconnectCounter = 0;
+    self->state = NimbleServerParticipantConnectionStateNormal;
+
+    statsIntInit(&self->incomingStepCountInBufferStats, 60);
+    // Expect that the client will add steps for the next authoritative step
+    nbsStepsReInit(&self->steps, currentAuthoritativeStepId);
+    self->transportConnection = transportConnection;
 }
 
 /// Checks if a participantId is in the participant connection

--- a/src/lib/participant_connection.c
+++ b/src/lib/participant_connection.c
@@ -28,6 +28,7 @@ void nimbleServerParticipantConnectionInit(NimbleServerParticipantConnection* se
     self->log = log;
     nbsStepsInit(&self->steps, connectionAllocator, combinedStepOctetSize, log);
     self->participantReferences.participantReferenceCount = 0;
+    self->waitingForReconnectMaxTimer = 62 * 20;
     self->isUsed = false;
     nimbleServerParticipantConnectionReInit(self, transportConnection, currentAuthoritativeStepId);
 }

--- a/src/lib/req_connect.c
+++ b/src/lib/req_connect.c
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Peter Bjorklund. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+#include <clog/clog.h>
+#include <flood/in_stream.h>
+#include <flood/out_stream.h>
+#include <nimble-serialize/server_in.h>
+#include <nimble-serialize/server_out.h>
+#include <nimble-server/errors.h>
+#include <nimble-server/game.h>
+#include <nimble-server/participant.h>
+#include <nimble-server/participant_connection.h>
+#include <nimble-server/req_connect.h>
+#include <nimble-server/server.h>
+
+/*
+    NimbleSerializeVersion nimbleProtocolVersion;
+    int errorCode = nimbleSerializeInVersion(inStream, &nimbleProtocolVersion);
+    if (errorCode < 0) {
+        CLOG_SOFT_ERROR("could not read nimble serialize version %d", errorCode)
+        return errorCode;
+    }
+
+    char buf[32];
+    CLOG_C_VERBOSE(&transportConnection->log, "request game state. nimble protocol version %s",
+                   nimbleSerializeVersionToString(&nimbleProtocolVersion, buf, 32))
+
+    if (!nimbleSerializeVersionIsEqual(&nimbleProtocolVersion, &g_nimbleProtocolVersion)) {
+
+        CLOG_SOFT_ERROR("wrong version of nimble protocol version. expected %s, but encountered %s",
+                        nimbleSerializeVersionToString(&g_nimbleProtocolVersion, buf, 32),
+                        nimbleSerializeVersionToString(&nimbleProtocolVersion, buf, 32))
+        return -41;
+    }
+
+    NimbleSerializeVersion clientApplicationVersion;
+    errorCode = nimbleSerializeInVersion(inStream, &clientApplicationVersion);
+    if (errorCode < 0) {
+        CLOG_SOFT_ERROR("wrong version %d", errorCode)
+        return errorCode;
+    }
+
+    CLOG_C_VERBOSE(&transportConnection->log, "request game state. application version version %s",
+                   nimbleSerializeVersionToString(&clientApplicationVersion, buf, 32))
+
+    if (!nimbleSerializeVersionIsEqual(&applicationVersion, &clientApplicationVersion)) {
+        CLOG_SOFT_ERROR("Wrong application version")
+        return -44;
+    }
+
+*/
+
+int nimbleServerReqConnect(NimbleServer* self, NimbleServerTransportConnection* transportConnection,
+                           FldInStream* inStream, FldOutStream* outStream)
+{
+    NimbleSerializeConnectRequest connectOptions;
+    int serializeErr = nimbleSerializeServerInConnectRequest(inStream, &connectOptions);
+    if (serializeErr < 0) {
+        return NimbleServerErrSerializeVersion;
+    }
+
+    transportConnection->useDebugStreams = connectOptions.useDebugStreams;
+
+    if (!nimbleSerializeVersionIsEqual(&self->applicationVersion, &connectOptions.applicationVersion)) {
+        CLOG_SOFT_ERROR("Wrong application version")
+        return NimbleServerErrSerializeVersion;
+    }
+
+    if (transportConnection->phase == NbTransportConnectionPhaseWaitingForValidConnect) {
+        transportConnection->phase = NbTransportConnectionPhaseConnected;
+    }
+
+    NimbleSerializeConnectResponse connectResponse;
+    connectResponse.useDebugStreams = transportConnection->useDebugStreams;
+
+    return nimbleSerializeServerOutConnectResponse(outStream, &connectResponse);
+}

--- a/src/lib/req_connect.c
+++ b/src/lib/req_connect.c
@@ -14,43 +14,6 @@
 #include <nimble-server/req_connect.h>
 #include <nimble-server/server.h>
 
-/*
-    NimbleSerializeVersion nimbleProtocolVersion;
-    int errorCode = nimbleSerializeInVersion(inStream, &nimbleProtocolVersion);
-    if (errorCode < 0) {
-        CLOG_SOFT_ERROR("could not read nimble serialize version %d", errorCode)
-        return errorCode;
-    }
-
-    char buf[32];
-    CLOG_C_VERBOSE(&transportConnection->log, "request game state. nimble protocol version %s",
-                   nimbleSerializeVersionToString(&nimbleProtocolVersion, buf, 32))
-
-    if (!nimbleSerializeVersionIsEqual(&nimbleProtocolVersion, &g_nimbleProtocolVersion)) {
-
-        CLOG_SOFT_ERROR("wrong version of nimble protocol version. expected %s, but encountered %s",
-                        nimbleSerializeVersionToString(&g_nimbleProtocolVersion, buf, 32),
-                        nimbleSerializeVersionToString(&nimbleProtocolVersion, buf, 32))
-        return -41;
-    }
-
-    NimbleSerializeVersion clientApplicationVersion;
-    errorCode = nimbleSerializeInVersion(inStream, &clientApplicationVersion);
-    if (errorCode < 0) {
-        CLOG_SOFT_ERROR("wrong version %d", errorCode)
-        return errorCode;
-    }
-
-    CLOG_C_VERBOSE(&transportConnection->log, "request game state. application version version %s",
-                   nimbleSerializeVersionToString(&clientApplicationVersion, buf, 32))
-
-    if (!nimbleSerializeVersionIsEqual(&applicationVersion, &clientApplicationVersion)) {
-        CLOG_SOFT_ERROR("Wrong application version")
-        return -44;
-    }
-
-*/
-
 int nimbleServerReqConnect(NimbleServer* self, NimbleServerTransportConnection* transportConnection,
                            FldInStream* inStream, FldOutStream* outStream)
 {

--- a/src/lib/req_game_join.c
+++ b/src/lib/req_game_join.c
@@ -107,6 +107,7 @@ int nimbleServerReqGameJoin(NimbleServer* self, NimbleServerTransportConnection*
         nimbleSerializeServerOutJoinGameOutOfParticipantSlotsResponse(outStream, request.nonce);
         return errorCode;
     }
+    createdConnection->waitingForReconnectMaxTimer = self->setup.maxWaitingForReconnectTicks;
 
     transportConnection->assignedParticipantConnection = createdConnection;
 

--- a/src/lib/req_game_join.c
+++ b/src/lib/req_game_join.c
@@ -41,6 +41,7 @@ static int nimbleServerGameJoinParticipantConnection(NimbleServerParticipantConn
             nimbleServerParticipantConnectionReInit(foundConnectionFromSecret, transportConnection,
                                                     latestAuthoritativeStepId);
             foundConnectionFromSecret->state = NimbleServerParticipantConnectionStateNormal;
+            foundConnectionFromSecret->waitingForReconnectTimer = 0;
             *outConnection = foundConnectionFromSecret;
             return 0;
         }

--- a/src/lib/req_game_join.c
+++ b/src/lib/req_game_join.c
@@ -13,6 +13,7 @@
 #include <nimble-server/participant_connection.h>
 #include <nimble-server/req_join_game.h>
 #include <nimble-server/server.h>
+#include <inttypes.h>
 
 static int nimbleServerGameJoinParticipantConnection(NimbleServerParticipantConnections* connections,
                                                      NimbleServerParticipants* gameParticipants,
@@ -123,9 +124,9 @@ int nimbleServerReqGameJoin(NimbleServer* self, NimbleServerTransportConnection*
     gameResponse.participantConnectionSecret = createdConnection->secret;
     gameResponse.participantCount = createdConnection->participantReferences.participantReferenceCount;
 
-    CLOG_DEBUG("client joined game with connection %u stateID: %04X participant count: %zu", createdConnection->id,
+    CLOG_C_DEBUG(&self->log, "client joined game with participant connection %u stateID: %04X participant count: %zu secret: %" PRIX64 , createdConnection->id,
                self->game.authoritativeSteps.expectedWriteId - 1,
-               createdConnection->participantReferences.participantReferenceCount)
+               createdConnection->participantReferences.participantReferenceCount, createdConnection->secret)
     nimbleSerializeServerOutJoinGameResponse(outStream, &gameResponse);
 
     return 0;

--- a/src/lib/req_game_state_ack.c
+++ b/src/lib/req_game_state_ack.c
@@ -56,6 +56,8 @@ int nimbleServerReqDownloadGameStateAck(NimbleServerTransportConnection* transpo
         // CLOG_DEBUG("sending state %08X (octet count :%zu)", options.stepId, options.gameStateOctetCount);
 
         fldOutStreamInit(&stream, buf, UDP_MAX_SIZE);
+        stream.writeDebugInfo = transportConnection->useDebugStreams;
+
         orderedDatagramOutLogicPrepare(&transportConnection->orderedDatagramOutLogic, &stream);
 
         nimbleSerializeWriteCommand(&stream, NimbleSerializeCmdGameStatePart, "");

--- a/src/lib/server.c
+++ b/src/lib/server.c
@@ -74,6 +74,8 @@ int nimbleServerFeed(NimbleServer* self, uint8_t connectionIndex, const uint8_t*
         return -54;
     }
 
+    inStream.readDebugInfo = transportConnection->useDebugStreams;
+
     orderedDatagramInLogicReceive(&transportConnection->orderedDatagramInLogic, &inStream);
 
     uint8_t cmd;
@@ -85,10 +87,12 @@ int nimbleServerFeed(NimbleServer* self, uint8_t connectionIndex, const uint8_t*
         return nimbleServerReqDownloadGameStateAck(transportConnection, &inStream, response->transportOut);
     }
 
+
 #define UDP_MAX_SIZE (1200)
     static uint8_t buf[UDP_MAX_SIZE];
     FldOutStream outStream;
     fldOutStreamInit(&outStream, buf, UDP_MAX_SIZE);
+    outStream.writeDebugInfo = transportConnection->useDebugStreams;
 
     orderedDatagramOutLogicPrepare(&transportConnection->orderedDatagramOutLogic, &outStream);
 

--- a/src/lib/server.c
+++ b/src/lib/server.c
@@ -15,6 +15,7 @@
 #include <nimble-server/req_download_game_state.h>
 #include <nimble-server/req_download_game_state_ack.h>
 #include <nimble-server/req_join_game.h>
+#include <nimble-server/req_connect.h>
 #include <nimble-server/req_step.h>
 #include <nimble-server/server.h>
 
@@ -98,6 +99,9 @@ int nimbleServerFeed(NimbleServer* self, uint8_t connectionIndex, const uint8_t*
 
     int result;
     switch (cmd) {
+       case NimbleSerializeCmdConnectRequest:
+            result = nimbleServerReqConnect(self, transportConnection, &inStream, &outStream);
+            break;
         case NimbleSerializeCmdGameStep:
             result = nimbleServerReqGameStep(&self->game, transportConnection, &self->authoritativeStepsPerSecondStat,
                                              &self->connections, &inStream, &outStream);
@@ -107,7 +111,7 @@ int nimbleServerFeed(NimbleServer* self, uint8_t connectionIndex, const uint8_t*
             break;
         case NimbleSerializeCmdDownloadGameStateRequest:
             result = nimbleServerReqDownloadGameState(transportConnection, self->pageAllocator, &self->game,
-                                                      self->applicationVersion, &inStream, &outStream);
+                                                      &inStream, &outStream);
             break;
         default:
             CLOG_SOFT_ERROR("nimbleServerFeed: unknown command %02X", data[0])

--- a/src/lib/transport_connection.c
+++ b/src/lib/transport_connection.c
@@ -24,6 +24,7 @@ void transportConnectionInit(NimbleServerTransportConnection* self, ImprintAlloc
     self->noRangesToSendCounter = 0;
     self->phase = NbTransportConnectionPhaseIdle;
     self->blobStreamOutClientRequestId = 0;
+    self->useDebugStreams = true;
 
     statsIntInit(&self->stepsBehindStats, 60);
 }


### PR DESCRIPTION
feat: 

- include a random secret in join game response to enable possible reconnect to the same participant connection by the client.
- add `maxWaitingForReconnectTicks` field in setup.
- have a more forgiving disconnect timeout until the first step (input) is received from the client (presumably is done with downloading the state)
- keep the participantConnection alive for reconnect (up to maxWaitingForReconnectTicks)
